### PR TITLE
Fix for bug #88012

### DIFF
--- a/Source/PKRevealController/PKRevealController.m
+++ b/Source/PKRevealController/PKRevealController.m
@@ -1260,10 +1260,9 @@ typedef NS_ENUM(NSUInteger , ZNLPKRevealControllerViewType)
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    if ([otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]
-        && [[[otherGestureRecognizer.view class] description] rangeOfString:@"UITableView"].length)
+    if ([otherGestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] && [[[otherGestureRecognizer.view class] description] rangeOfString:@"UITableView"].length)
     {
-        return YES;
+        return ((UITableView *)otherGestureRecognizer.view).isEditing;
     }
     return NO;
 }


### PR DESCRIPTION
#88011:Unable to swipe to left hand menu from the items list area of the basket - iPad

Pan gestures should only be disabled if the tableView is being edited
